### PR TITLE
Add secure upload handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Project directories
+uploads/
+results/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A continuacion se muestra un conjunto de pasos detallados para crear el proyecto
 7. **Contenido basico del README**
    - Explica que la aplicacion permite separar audio y generar archivos MIDI.
    - Menciona las dependencias y como instalarlas.
+   - Los archivos admitidos para la subida son `.mp3` y `.wav`.
 8. **Instalacion y ejecucion**
    ```bash
    python -m venv venv

--- a/app.py
+++ b/app.py
@@ -1,0 +1,36 @@
+from flask import Flask, request, redirect, render_template, flash
+from werkzeug.utils import secure_filename
+import os
+
+app = Flask(__name__)
+app.secret_key = 'change_me'
+UPLOAD_FOLDER = 'uploads'
+ALLOWED_EXTENSIONS = {"mp3", "wav"}
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
+
+def allowed_file(filename: str) -> bool:
+    """Return True if the filename has an allowed extension."""
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+@app.route('/', methods=['GET', 'POST'])
+def upload():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if not file or file.filename == '':
+            flash('No file selected')
+            return redirect(request.url)
+        if not allowed_file(file.filename):
+            flash('Solo se permiten archivos .mp3 o .wav')
+            return redirect(request.url)
+        filename = secure_filename(file.filename)
+        os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+        file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+        flash('Archivo subido correctamente')
+        return redirect(request.url)
+    return render_template('index.html')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- implement basic Flask app with `allowed_file` helper and secure uploads
- mention supported `.mp3` and `.wav` types in README
- ignore project output directories in gitignore

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6884db2d9e3c8330ac263062b3ec01de