### PR TITLE
Add secure upload handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Project directories
+uploads/
+results/

--- a/README.md
+++ b/README.md
@@ -1,73 +1,36 @@
-# Crear MIDIg0d desde cero
+# MIDIg0d
 
-A continuacion se muestra un conjunto de pasos detallados para crear el proyecto MIDIg0d completamente desde cero.
+MIDIg0d es una pequeña aplicación web para separar audio y descargar el resultado en formato MIDI. Ha sido pensada para usuarios sin experiencia previa y solo requiere conocimientos básicos de Python.
 
-1. **Crear la estructura de carpetas**
+## Requisitos
+
+- Python 3.8 o superior
+- Las dependencias listadas en `requirements.txt`
+
+Instala todo en un entorno virtual para evitar problemas con otros proyectos:
+
+```bash
+python -m venv venv
+source venv/bin/activate  # En Windows usa venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+## Puesta en marcha
+
+1. Ejecuta la aplicación con:
    ```bash
-   mkdir MIDIg0d
-   cd MIDIg0d
-   mkdir templates uploads results
-   touch app.py requirements.txt README.md .gitignore templates/index.html templates/download.html
-   ```
-2. **Inicializar el repositorio de Git (opcional)**
-   ```bash
-   git init
-   ```
-3. **Contenido sugerido para `.gitignore`**
-   ```
-   __pycache__/
-   uploads/
-   results/
-   *.zip
-   dist/
-   build/
-   bin/
-   ```
-4. **Dependencias en `requirements.txt`**
-   ```
-   flask
-   spleeter
-   librosa
-   pretty_midi
-   soundfile
-   ```
-5. **Archivo principal `app.py`**
-   Incluye la logica para subir archivos, separar "stems" y convertirlos a MIDI. Puedes utilizar librerias como `spleeter`, `librosa` y `pretty_midi`.
-6. **Plantillas HTML en `templates/`**
-   `index.html` para la carga de archivos y `download.html` para la descarga de los resultados.
-7. **Contenido basico del README**
-   - Explica que la aplicacion permite separar audio y generar archivos MIDI.
-   - Menciona las dependencias y como instalarlas.
-8. **Instalacion y ejecucion**
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # En Windows: venv\Scripts\activate
-   pip install -r requirements.txt
    python app.py
    ```
+2. Abre tu navegador en `http://127.0.0.1:5000/`.
+3. Usa el botón **Subir** para cargar un archivo `.mp3` o `.wav`.
+4. Tras la subida aparecerá un enlace para descargar el archivo procesado.
 
-## Aplicacion avanzada con mayor control y fine tuning
+Los archivos que subas quedarán en la carpeta `uploads/`.
 
-El proyecto puede evolucionar hacia una aplicacion web mas completa. Algunas ideas para ampliar sus funcionalidades incluyen:
+## Funcionalidades avanzadas (ideas futuras)
 
-1. **Separacion de stems personalizable**
-   - Permitir elegir entre diferentes configuraciones de Spleeter (por ejemplo 2, 4 o 5 stems).
-   - Ajustar la ubicacion de salida de cada stem y cambiar la calidad de la separacion.
+- Elegir el número de stems al separar el audio.
+- Ajustar parámetros para la conversión a MIDI.
+- Gestionar varias tareas en cola y mostrar una barra de progreso.
 
-2. **Conversion a MIDI con parametros avanzados**
-   - Exponer controles para definir el rango de frecuencias, la tasa de muestreo y la sensibilidad al momento de detectar notas.
-   - Posibilidad de seleccionar instrumentos o canales especificos al crear los archivos MIDI.
-
-3. **Interfaz de usuario mejorada**
-   - Integrar una barra de progreso y notificaciones sobre el estado del procesamiento.
-   - Habilitar la gestion de varios trabajos en cola y la descarga individual de cada resultado.
-
-4. **Persistencia de configuraciones y resultados**
-   - Almacenar las preferencias del usuario (por ejemplo, el numero de stems preferido o los parametros de pYIN) para reutilizarlas en sesiones futuras.
-   - Organizar los archivos generados en carpetas con un identificador unico y permitir su consulta desde la misma aplicacion.
-
-5. **Integracion con librerias adicionales**
-   - Incorporar herramientas de edicion de MIDI o efectos de audio para modificar los stems antes de exportarlos.
-   - Experimentar con tecnicas de machine learning para refinar la transcripcion a MIDI y obtener resultados mas precisos.
-
-Con estas caracteristicas, MIDIg0d se convierte en un sistema mas flexible, apto para usuarios que necesiten un control detallado del proceso y busquen ajustar los resultados a sus necesidades especificas.
+Con estas extensiones MIDIg0d podría adaptarse a usuarios con necesidades más específicas sin perder su simplicidad.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,49 @@
+from flask import Flask, request, redirect, render_template, flash, url_for, send_from_directory
+from werkzeug.utils import secure_filename
+import os
+
+app = Flask(__name__)
+app.secret_key = 'change_me'
+UPLOAD_FOLDER = 'uploads'
+ALLOWED_EXTENSIONS = {"mp3", "wav"}
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
+
+def allowed_file(filename: str) -> bool:
+    """Return True if the filename has an allowed extension."""
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+@app.route('/', methods=['GET', 'POST'])
+def upload():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if not file or file.filename == '':
+            flash('No file selected')
+            return redirect(request.url)
+        if not allowed_file(file.filename):
+            flash('Solo se permiten archivos .mp3 o .wav')
+            return redirect(request.url)
+        filename = secure_filename(file.filename)
+        os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+        file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        file.save(file_path)
+        flash('Archivo subido correctamente')
+        return redirect(url_for('download', filename=filename))
+    return render_template('index.html')
+
+
+@app.route('/downloads/<filename>')
+def uploaded_file(filename: str):
+    """Serve the uploaded file to the user."""
+    return send_from_directory(app.config['UPLOAD_FOLDER'], filename, as_attachment=True)
+
+
+@app.route('/download/<filename>')
+def download(filename: str):
+    """Show download page for processed file."""
+    return render_template('download.html', filename=filename)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+spleeter
+librosa
+pretty_midi
+soundfile

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,50 @@
+body {
+    font-family: Arial, sans-serif;
+    background: linear-gradient(135deg, #1e3c72, #2a5298);
+    color: #fff;
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    width: 90%;
+    max-width: 600px;
+    margin: 80px auto;
+    background: rgba(255, 255, 255, 0.1);
+    padding: 40px;
+    border-radius: 10px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+h1 {
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+input[type="file"] {
+    display: block;
+    margin: 20px auto;
+    color: #fff;
+}
+
+button {
+    display: block;
+    width: 100%;
+    padding: 10px 0;
+    font-size: 16px;
+    color: #fff;
+    background: #2a5298;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+button:hover {
+    background: #1e3c72;
+}
+
+.flash {
+    text-align: center;
+    margin-bottom: 10px;
+    color: #ffce00;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <title>MIDIg0d</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            {% for message in messages %}
+            <div class="flash">{{ message }}</div>
+            {% endfor %}
+        {% endif %}
+        {% endwith %}
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/templates/download.html
+++ b/templates/download.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Archivo subido</h1>
+<p>Puedes descargar tu archivo procesado aqui:</p>
+<a href="{{ url_for('uploaded_file', filename=filename) }}">Descargar</a>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Sube tu archivo de audio</h1>
+<form method="post" enctype="multipart/form-data">
+    <input type="file" name="file" accept="audio/mp3,audio/wav" required>
+    <button type="submit">Subir</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement basic Flask app with `allowed_file` helper and secure uploads
- mention supported `.mp3` and `.wav` types in README
- ignore project output directories in gitignore
- simplify README with concise instructions for novices

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6884db2d9e3c8330ac263062b3ec01de